### PR TITLE
Fix bug where offline warning message was not shown in the AppBar.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-storefront",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "description": "Build and deploy e-commerce progressive web apps (PWAs) in record time.",
   "module": "./index.js",
   "license": "Apache-2.0",

--- a/src/AppBar.js
+++ b/src/AppBar.js
@@ -67,7 +67,7 @@ export default function AppBar({ children, style, fixed, offlineWarning, classes
 
   if (!fixed) {
     appBar = (
-      <Slide appear={false} direction="down" in={!trigger}>
+      <Slide in={!trigger}>
         {appBar}
       </Slide>
     )

--- a/src/AppBar.js
+++ b/src/AppBar.js
@@ -14,12 +14,17 @@ const useStyles = makeStyles(theme => ({
     boxShadow: 'none',
     borderBottom: `1px solid ${theme.palette.divider}`,
     zIndex: theme.zIndex.modal + 10,
+    height: theme.headerHeight,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'stretch',
   },
   /**
    * Styles applied to the spacer that fills the height behind the floating toolbar.
    */
   spacer: {
     boxSizing: 'border-box',
+    height: theme.headerHeight,
   },
   /**
    * Styles applied to the `Toolbar` element.
@@ -27,12 +32,7 @@ const useStyles = makeStyles(theme => ({
   toolbar: {
     justifyContent: 'space-between',
     alignItems: 'center',
-  },
-  /**
-   * Styles applied to the inner `Container` element.
-   */
-  container: {
-    padding: 0,
+    flex: 1,
   },
   /**
    * Styles applied to the offline warning element.
@@ -46,9 +46,9 @@ const useStyles = makeStyles(theme => ({
   },
 }))
 
-export default function AppBar({ height, maxWidth, children, style, fixed, offlineWarning }) {
+export default function AppBar({ children, style, fixed, offlineWarning, classes }) {
   const trigger = useScrollTrigger()
-  const classes = useStyles()
+  classes = useStyles({ classes })
 
   const { offline } = useContext(PWAContext)
 
@@ -56,15 +56,12 @@ export default function AppBar({ height, maxWidth, children, style, fixed, offli
     <MUIAppBar
       className={classes.root}
       style={{
-        height,
         ...style,
       }}
     >
-      <Container maxWidth={maxWidth} className={classes.container}>
-        <Toolbar disableGutters className={classes.toolbar}>
-          {children}
-        </Toolbar>
-      </Container>
+      <Toolbar disableGutters className={classes.toolbar}>
+        {children}
+      </Toolbar>
     </MUIAppBar>
   )
 
@@ -78,31 +75,18 @@ export default function AppBar({ height, maxWidth, children, style, fixed, offli
 
   return (
     <>
-      <div style={{ height }} className={classes.spacer} />
+      <div className={classes.spacer} />
       {offline && <div className={classes.offline}>{offlineWarning}</div>}
       {appBar}
     </>
   )
 }
 
-/**
- * The height of the AppBar
- */
 AppBar.propTypes = {
   /**
    * Override or extend the styles applied to the component. See [CSS API](#css) below for more details.
    */
   classes: PropTypes.object,
-
-  /**
-   * The height of the AppBar in pixels
-   */
-  height: PropTypes.number,
-
-  /**
-   * The max width for the inner toolbar
-   */
-  maxWidth: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']),
 
   /**
    * Set as `true` if the AppBar should be fixed position.
@@ -116,8 +100,6 @@ AppBar.propTypes = {
 }
 
 AppBar.defaultProps = {
-  height: 58,
-  maxWidth: 'lg',
   offlineWarning: 'Your device lost its internet connection.',
   fixed: false,
 }

--- a/src/PWA.js
+++ b/src/PWA.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import PWAContext from './PWAContext'
 import PropTypes from 'prop-types'
 import ErrorBoundary from './ErrorBoundary'
@@ -28,12 +28,14 @@ const useStyles = makeStyles(styles, { name: 'RSFPWA' })
 export default function PWA({ children, errorReporter }) {
   useStyles()
   const thumbnail = useRef(null)
+  const [offline, setOffline] = useState(typeof navigator !== 'undefined' && !navigator.onLine)
 
   const context = useMemo(
     () => ({
       thumbnail,
+      offline,
     }),
-    [],
+    [offline],
   )
 
   // enable client-side navigation when the user clicks a simple HTML anchor element
@@ -42,17 +44,16 @@ export default function PWA({ children, errorReporter }) {
   useEffect(() => {
     context.hydrating = false
 
-    // const handleOnline = () => (app.offline = false)
-    // const handleOffline = () => (app.offline = true)
+    const handleOnline = () => setOffline(false)
+    const handleOffline = () => setOffline(true)
 
-    // app.offline = !navigator.onLine
-    // window.addEventListener('online', handleOnline)
-    // window.addEventListener('offline', handleOffline)
+    window.addEventListener('online', handleOnline)
+    window.addEventListener('offline', handleOffline)
 
-    // return () => {
-    //   window.removeEventListener('online', handleOnline)
-    //   window.removeEventListener('offline', handleOffline)
-    // }
+    return () => {
+      window.removeEventListener('online', handleOnline)
+      window.removeEventListener('offline', handleOffline)
+    }
   }, [])
 
   return (

--- a/src/drawer/DrawerCloseButton.js
+++ b/src/drawer/DrawerCloseButton.js
@@ -37,6 +37,7 @@ export const styles = theme => ({
     right: '10px',
     top: '-28px',
     zIndex: 1,
+    color: 'white',
   },
   /**
    * Styles applied to hide the `Fab` button when [`open`](#prop-open) is `false`.

--- a/src/props/fetchFromAPI.js
+++ b/src/props/fetchFromAPI.js
@@ -30,6 +30,7 @@ export default function fetchFromAPI({ req, asPath }) {
   const protocol = server ? (host.startsWith('localhost') ? 'http://' : 'https://') : ''
 
   if (asPath === '/') asPath = ''
+  if (asPath.startsWith('/?')) asPath = asPath.substring(1)
 
   let uri = `/api${asPath}`
 

--- a/src/search/SearchDrawer.js
+++ b/src/search/SearchDrawer.js
@@ -19,7 +19,7 @@ export default function SearchDrawer({ DrawerComponent, classes, open, onClose, 
   classes = useStyles({ classes })
 
   return (
-    <SearchProvider onClose={onClose}>
+    <SearchProvider onClose={onClose} open={open}>
       <DrawerComponent classes={classes} open={open} anchor="bottom" onClose={onClose} fullscreen>
         {children}
       </DrawerComponent>

--- a/src/search/SearchProvider.js
+++ b/src/search/SearchProvider.js
@@ -8,17 +8,17 @@ import useNavigationEvent from '../hooks/useNavigationEvent'
 
 const fetch = fetchLatest(_fetch)
 
-export default function SearchProvider({ children, initialGroups, onClose }) {
+export default function SearchProvider({ children, initialGroups, onClose, open }) {
   const [state, setState] = useState({
     groups: initialGroups,
     loading: true,
   })
 
   useEffect(() => {
-    if (state.groups == null) {
+    if (open && state.groups == null) {
       fetchSuggestions('')
     }
-  }, [])
+  }, [open])
 
   useNavigationEvent(onClose)
 
@@ -69,6 +69,7 @@ export default function SearchProvider({ children, initialGroups, onClose }) {
 }
 
 SearchProvider.propTypes = {
+  open: PropTypes.bool,
   initialGroups: PropTypes.array,
   onClose: PropTypes.func,
 }

--- a/src/search/SearchSuggestions.js
+++ b/src/search/SearchSuggestions.js
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
-import PropTypes from 'prop-types'
 import SearchSuggestionGroup from './SearchSuggestionGroup'
 import SearchContext from './SearchContext'
 import LoadMask from '../LoadMask'
@@ -8,6 +7,7 @@ import LoadMask from '../LoadMask'
 export const styles = theme => ({
   root: {
     flex: 1,
+    position: 'relative',
     overflowY: 'auto',
   },
   group: {

--- a/test/AppBar.test.js
+++ b/test/AppBar.test.js
@@ -2,85 +2,21 @@ import React from 'react'
 import { mount } from 'enzyme'
 import AppBar from 'react-storefront/AppBar'
 import PWAContext from 'react-storefront/PWAContext'
-import { eventListenersMock } from './mocks/mockHelper'
 import { MuiThemeProvider } from '@material-ui/core/styles'
-import { Toolbar } from '@material-ui/core'
-import { act } from 'react-dom/test-utils'
-import { createMuiTheme } from '@material-ui/core/styles'
-import { red } from '@material-ui/core/colors'
+import createTheme from 'react-storefront/theme/createTheme'
+import { Slide } from '@material-ui/core'
 
 // Create a theme instance.
-const theme = createMuiTheme({
-  palette: {
-    primary: {
-      main: '#556cd6',
-    },
-    secondary: {
-      main: '#19857b',
-    },
-    error: {
-      main: red.A400,
-    },
-    background: {
-      default: '#fff',
-    },
-  },
-  zIndex: {
-    modal: 999,
-    amp: {
-      modal: 2147483646,
-    },
-  },
-  headerHeight: 64,
-  loadMaskOffsetTop: 64 + 56 + 4,
-  drawerWidth: 330,
-  margins: {
-    container: 16,
-  },
-  overrides: {},
-})
+const theme = createTheme()
 
 jest.useFakeTimers()
 
 describe('AppBar', () => {
-  const initialScrollY = window.scrollY
-  let wrapper,
-    offline,
-    open,
-    offlineMessage,
-    fixed,
-    map = {}
+  let wrapper
 
-  const getClassNames = () =>
-    wrapper
-      .find(Toolbar)
-      .parent()
-      .prop('className')
-
-  beforeEach(() => {
-    eventListenersMock(map)
-  })
-
-  afterAll(() => {
-    jest.restoreAllMocks()
-  })
-
-  afterEach(async () => {
-    act(() => {
-      jest.runAllTimers()
-    })
-    wrapper.unmount()
-    window.scrollY = initialScrollY
-    offline = undefined
-    open = undefined
-    offlineMessage = undefined
-    fixed = undefined
-    map = {}
-  })
-
-  const Test = () => {
+  const Test = ({ offline = false, offlineMessage, fixed = false }) => {
     return (
-      <PWAContext.Provider value={{ menu: { open }, offline }}>
+      <PWAContext.Provider value={{ offline }}>
         <MuiThemeProvider theme={theme}>
           <AppBar offlineWarning={offlineMessage} fixed={fixed} />
         </MuiThemeProvider>
@@ -89,181 +25,195 @@ describe('AppBar', () => {
   }
 
   it('should render offline message when offline', () => {
-    offline = true
-    offlineMessage = 'offlineTestMessage'
-    wrapper = mount(<Test />)
-
-    expect(wrapper.find(AppBar).text()).toBe(offlineMessage)
+    const message = 'offlineTestMessage'
+    wrapper = mount(<Test offlineMessage={message} offline />)
+    expect(wrapper.find(AppBar).text()).toEqual(message)
   })
 
-  it('should not have any classes except wrap when not scrolled', async () => {
-    window.scrollY = 0
-
-    wrapper = mount(<Test />)
-
-    await act(async () => {
-      await map.scroll()
-      await wrapper.update()
-    })
-
-    const classNames = getClassNames()
-
-    expect(classNames).not.toContain('hidden')
-    expect(classNames).not.toContain('stuck')
+  it('should not render offline message when online', () => {
+    const message = 'offlineTestMessage'
+    wrapper = mount(<Test offlineMessage={message} />)
+    expect(wrapper.find(AppBar).text()).toEqual('')
   })
 
-  it('should not call scroll when fixed prop is passed', async () => {
-    fixed = true
-
+  it('should slide in when fixed is false', () => {
     wrapper = mount(<Test />)
-
-    const classNames = getClassNames()
-
-    expect(classNames).not.toContain('hidden')
-    expect(classNames).not.toContain('unstuck')
-    expect(classNames).toContain('fixed')
-    expect(map.scroll).toBe(undefined)
+    expect(wrapper.find(Slide)).toHaveLength(1)
   })
 
-  it('should not show AppBar when scrolling down', async () => {
-    wrapper = mount(<Test />)
-
-    window.scrollY = 250
-    await act(async () => {
-      await map.scroll()
-      await wrapper.update()
-    })
-
-    expect(getClassNames()).toContain('unstuck')
+  it('should not slide in when fixed is true', () => {
+    wrapper = mount(<Test fixed />)
+    expect(wrapper.find(Slide)).toHaveLength(0)
   })
 
-  it('should show AppBar when scrolling up again', async () => {
-    wrapper = mount(<Test />)
+  // it('should not have any classes except wrap when not scrolled', async () => {
+  //   window.scrollY = 0
 
-    window.scrollY = 0
-    await act(async () => {
-      await map.scroll()
-      await wrapper.update()
-    })
+  //   wrapper = mount(<Test />)
 
-    window.scrollY = 250
-    await act(async () => {
-      await map.scroll()
-      await wrapper.update()
-    })
+  //   await act(async () => {
+  //     await map.scroll()
+  //     await wrapper.update()
+  //   })
 
-    expect(getClassNames()).toContain('unstuck')
+  //   const classNames = getClassNames()
 
-    window.scrollY = 200
+  //   expect(classNames).not.toContain('hidden')
+  //   expect(classNames).not.toContain('stuck')
+  // })
 
-    await act(async () => {
-      await map.scroll()
-      await wrapper.update()
-    })
+  // it('should not call scroll when fixed prop is passed', async () => {
+  //   fixed = true
 
-    expect(getClassNames()).not.toContain('unstuck')
-  })
+  //   wrapper = mount(<Test />)
 
-  it('should not show AppBar  when scrolling up again less than buffer', async () => {
-    wrapper = mount(<Test />)
+  //   const classNames = getClassNames()
 
-    window.scrollY = 0
-    await act(async () => {
-      await map.scroll()
-      await wrapper.update()
-    })
+  //   expect(classNames).not.toContain('hidden')
+  //   expect(classNames).not.toContain('unstuck')
+  //   expect(classNames).toContain('fixed')
+  //   expect(map.scroll).toBe(undefined)
+  // })
 
-    window.scrollY = 250
-    await act(async () => {
-      await map.scroll()
-      await wrapper.update()
-    })
+  // it('should not show AppBar when scrolling down', async () => {
+  //   wrapper = mount(<Test />)
 
-    expect(getClassNames()).toContain('unstuck')
+  //   window.scrollY = 250
+  //   await act(async () => {
+  //     await map.scroll()
+  //     await wrapper.update()
+  //   })
 
-    window.scrollY = 240
+  //   expect(getClassNames()).toContain('unstuck')
+  // })
 
-    await act(async () => {
-      await map.scroll()
-      await wrapper.update()
-    })
+  // it('should show AppBar when scrolling up again', async () => {
+  //   wrapper = mount(<Test />)
 
-    expect(getClassNames()).toContain('unstuck')
-  })
+  //   window.scrollY = 0
+  //   await act(async () => {
+  //     await map.scroll()
+  //     await wrapper.update()
+  //   })
 
-  it('should not hide AppBar when scrolling down less than buffer', async () => {
-    wrapper = mount(<Test />)
+  //   window.scrollY = 250
+  //   await act(async () => {
+  //     await map.scroll()
+  //     await wrapper.update()
+  //   })
 
-    window.scrollY = 0
-    await act(async () => {
-      await map.scroll()
-      await wrapper.update()
-    })
+  //   expect(getClassNames()).toContain('unstuck')
 
-    window.scrollY = 250
-    await act(async () => {
-      await map.scroll()
-      await wrapper.update()
-    })
+  //   window.scrollY = 200
 
-    window.scrollY = 200
+  //   await act(async () => {
+  //     await map.scroll()
+  //     await wrapper.update()
+  //   })
 
-    await act(async () => {
-      await map.scroll()
-      await wrapper.update()
-    })
+  //   expect(getClassNames()).not.toContain('unstuck')
+  // })
 
-    window.scrollY = 150 // If we breach 180(150 + buffer(30)) AppBar will disappear
+  // it('should not show AppBar  when scrolling up again less than buffer', async () => {
+  //   wrapper = mount(<Test />)
 
-    await act(async () => {
-      await map.scroll()
-      await wrapper.update()
-    })
+  //   window.scrollY = 0
+  //   await act(async () => {
+  //     await map.scroll()
+  //     await wrapper.update()
+  //   })
 
-    window.scrollY = 170
+  //   window.scrollY = 250
+  //   await act(async () => {
+  //     await map.scroll()
+  //     await wrapper.update()
+  //   })
 
-    await act(async () => {
-      await map.scroll()
-      await wrapper.update()
-    })
+  //   expect(getClassNames()).toContain('unstuck')
 
-    expect(getClassNames()).not.toContain('unstuck') // AppBar is shown
+  //   window.scrollY = 240
 
-    window.scrollY = 181 // 180 breached
+  //   await act(async () => {
+  //     await map.scroll()
+  //     await wrapper.update()
+  //   })
 
-    await act(async () => {
-      await map.scroll()
-      await wrapper.update()
-    })
+  //   expect(getClassNames()).toContain('unstuck')
+  // })
 
-    expect(getClassNames()).toContain('unstuck') // AppBar not shown anymore, because scrolled more than buffer(buffer is 30)
-  })
+  // it('should not hide AppBar when scrolling down less than buffer', async () => {
+  //   wrapper = mount(<Test />)
 
-  it('should not have animate when going back to the top', async () => {
-    wrapper = mount(<Test />)
+  //   window.scrollY = 0
+  //   await act(async () => {
+  //     await map.scroll()
+  //     await wrapper.update()
+  //   })
 
-    window.scrollY = 0
-    await act(async () => {
-      await map.scroll()
-      await wrapper.update()
-    })
+  //   window.scrollY = 250
+  //   await act(async () => {
+  //     await map.scroll()
+  //     await wrapper.update()
+  //   })
 
-    window.scrollY = 250
-    await act(async () => {
-      await map.scroll()
-      await jest.runAllTimers()
-      await wrapper.update()
-    })
+  //   window.scrollY = 200
 
-    expect(getClassNames()).toContain('animate')
+  //   await act(async () => {
+  //     await map.scroll()
+  //     await wrapper.update()
+  //   })
 
-    window.scrollY = 0
+  //   window.scrollY = 150 // If we breach 180(150 + buffer(30)) AppBar will disappear
 
-    await act(async () => {
-      await map.scroll()
-      await wrapper.update()
-    })
+  //   await act(async () => {
+  //     await map.scroll()
+  //     await wrapper.update()
+  //   })
 
-    expect(getClassNames()).not.toContain('animate')
-  })
+  //   window.scrollY = 170
+
+  //   await act(async () => {
+  //     await map.scroll()
+  //     await wrapper.update()
+  //   })
+
+  //   expect(getClassNames()).not.toContain('unstuck') // AppBar is shown
+
+  //   window.scrollY = 181 // 180 breached
+
+  //   await act(async () => {
+  //     await map.scroll()
+  //     await wrapper.update()
+  //   })
+
+  //   expect(getClassNames()).toContain('unstuck') // AppBar not shown anymore, because scrolled more than buffer(buffer is 30)
+  // })
+
+  // it('should not have animate when going back to the top', async () => {
+  //   wrapper = mount(<Test />)
+
+  //   window.scrollY = 0
+  //   await act(async () => {
+  //     await map.scroll()
+  //     await wrapper.update()
+  //   })
+
+  //   window.scrollY = 250
+  //   await act(async () => {
+  //     await map.scroll()
+  //     await jest.runAllTimers()
+  //     await wrapper.update()
+  //   })
+
+  //   expect(getClassNames()).toContain('animate')
+
+  //   window.scrollY = 0
+
+  //   await act(async () => {
+  //     await map.scroll()
+  //     await wrapper.update()
+  //   })
+
+  //   expect(getClassNames()).not.toContain('animate')
+  // })
 })

--- a/test/PWA.test.js
+++ b/test/PWA.test.js
@@ -1,16 +1,41 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { mount } from 'enzyme'
 import PWA from 'react-storefront/PWA'
+import PWAContext from 'react-storefront/PWAContext'
+import { eventListenersMock } from './mocks/mockHelper'
+import { act } from 'react-dom/test-utils'
 
 describe('PWA', () => {
-  let wrapper
+  const map = {}
+  let wrapper, onLine, getOffline
+
+  const TestComponent = () => {
+    const { offline } = useContext(PWAContext)
+    getOffline = offline
+
+    return <div>{offline}</div>
+  }
+
+  beforeAll(() => {
+    eventListenersMock(map)
+  })
+
+  afterAll(() => {
+    jest.restoreAllMocks()
+  })
 
   afterEach(() => {
     wrapper.unmount()
+    onLine = undefined
+    getOffline = undefined
+  })
+
+  beforeEach(() => {
+    fetch.mockResponseOnce(JSON.stringify({}))
+    jest.spyOn(window, 'navigator', 'get').mockImplementation(options => ({ ...options, onLine }))
   })
 
   it('should render children', () => {
-    fetch.mockResponseOnce(JSON.stringify({}))
     wrapper = mount(
       <PWA>
         <div id="test">test</div>
@@ -18,5 +43,41 @@ describe('PWA', () => {
     )
 
     expect(wrapper.find('#test')).toExist()
+  })
+
+  it('should manage the offline and online state when default state is online', () => {
+    onLine = true
+
+    wrapper = mount(
+      <PWA>
+        <TestComponent />
+      </PWA>,
+    )
+
+    expect(getOffline).toBe(false)
+
+    act(() => {
+      map.offline()
+    })
+
+    expect(getOffline).toBe(true)
+  })
+
+  it('should manage the offline and online state when default state is offline', () => {
+    onLine = false
+
+    wrapper = mount(
+      <PWA>
+        <TestComponent />
+      </PWA>,
+    )
+
+    expect(getOffline).toBe(true)
+
+    act(() => {
+      map.online()
+    })
+
+    expect(getOffline).toBe(false)
   })
 })

--- a/test/profile.test.js
+++ b/test/profile.test.js
@@ -1,0 +1,35 @@
+import profile from 'react-storefront/profile'
+
+describe('profile', () => {
+  const originalLog = console.log
+  const originalNodeEnv = process.env.NODE_ENV
+  let mockLog
+
+  beforeEach(() => {
+    process.env.NODE_ENV = 'development'
+    mockLog = console.log = jest.fn()
+  })
+
+  afterEach(() => {
+    console.log = originalLog
+    process.env.NODE_ENV = originalNodeEnv
+  })
+
+  describe('development', () => {
+    it('should log the execution time', () => {
+      profile('testing profile', () => {})
+      expect(mockLog).toHaveBeenCalledWith('testing profile', expect.stringMatching(/.* ms/))
+    })
+  })
+
+  describe('production', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'production'
+    })
+
+    it('should not log the execution time', () => {
+      profile('testing profile', () => {})
+      expect(mockLog).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/test/props/fetchFromAPI.test.js
+++ b/test/props/fetchFromAPI.test.js
@@ -37,6 +37,13 @@ describe('fetchFromAPI', () => {
       })
       expect(fetch).toHaveBeenCalledWith('/api', headers)
     })
+
+    it('should append query params directly to api if the root with query params is called', () => {
+      fetchFromAPI({
+        asPath: '/?test=1',
+      })
+      expect(fetch).toHaveBeenCalledWith('/api?test=1', headers)
+    })
   })
 
   describe('on the server', () => {

--- a/test/search/SearchProvider.test.js
+++ b/test/search/SearchProvider.test.js
@@ -58,11 +58,7 @@ describe('SearchProvider', () => {
       </SearchProvider>,
     )
 
-    await act(async () => {
-      await sleep(300) // to trigger debounce
-      await wrapper.update()
-      expect(context.state.groups).toBe(undefined) // check that suggestions aren't fetched on mount
-    })
+    expect(context.state.groups).toBe(undefined) // check that suggestions aren't fetched on mount
 
     await act(async () => {
       wrapper.setProps({ open: true })

--- a/test/search/SearchProvider.test.js
+++ b/test/search/SearchProvider.test.js
@@ -49,7 +49,7 @@ describe('SearchProvider', () => {
     expect(onCloseMock).toHaveBeenCalled()
   })
 
-  it('should fetch suggestions', async () => {
+  it('should fetch suggestions the first time open is set to true', async () => {
     fetch.mockResponseOnce(JSON.stringify({ groups: 'test' }))
 
     wrapper = mount(
@@ -59,11 +59,18 @@ describe('SearchProvider', () => {
     )
 
     await act(async () => {
-      await sleep(250) // to trigger debounce
+      await sleep(300) // to trigger debounce
+      await wrapper.update()
+      expect(context.state.groups).toBe(undefined) // check that suggestions aren't fetched on mount
+    })
+
+    await act(async () => {
+      wrapper.setProps({ open: true })
+      await sleep(300) // to trigger debounce
       await wrapper.update()
     })
 
-    expect(context.state.groups).toBe('test')
+    expect(context.state.groups).toBe('test') // check that suggestions are fetched only after open is set to true
   })
 
   it('should catch fetch errors and set loading to false', async () => {


### PR DESCRIPTION
Fixes #32 

Also, removes our internal handling of the scroll event to show and hide the AppBar in favor of `useScrollTrigger` as suggested [here](https://material-ui.com/components/app-bar/#hide-app-bar). 