### PR TITLE
Change SW destination to static folder

### DIFF
--- a/plugins/withServiceWorker.js
+++ b/plugins/withServiceWorker.js
@@ -10,6 +10,7 @@ module.exports = function withServiceWorker(config, bootstrapPath) {
     ...config,
     generateInDevMode,
     workboxOpts: {
+      swDest: 'static/service-worker.js',
       clientsClaim: true,
       skipWaiting: true,
       importScripts: [


### PR DESCRIPTION
The SW request is returning 404 for the starter app deployed on now.sh. 
The solution as described in this thread(https://github.com/hanford/next-offline/issues/86) and used on nextjs demo (https://github.com/zeit/next.js/blob/canary/examples/with-next-offline/next.config.js) is to move service-worker.js to the static folder in `.next`.
If this PR gets approved, I can open another one to update `server.js` in the starter-app repo
