### PR TITLE
Removed the console message about preact.

### DIFF
--- a/plugins/withReactStorefront.js
+++ b/plugins/withReactStorefront.js
@@ -11,16 +11,6 @@ const chalk = require('chalk')
 module.exports = (nextConfig = {}) => {
   const usePreact = process.env.preact === 'true'
 
-  console.log(
-    `> Using ${
-      usePreact
-        ? chalk.green('preact') +
-          '. Set "preact" environment variable to "false" to use react instead.'
-        : chalk.blue('react') +
-          '. Set "preact" environment variable to "true" to use preact instead.'
-    }`,
-  )
-
   return phase => {
     const bootstrapOptions = {
       prefetchRampUpTime: -5000,


### PR DESCRIPTION
Removing the message about preact as it shows up twice when building with `xdn build` and might cause confusion.  Preact doesn't seem to be giving us any gain in perf anyway (actually we get a lower PSI score), so we'll just relegate that option to the docs.