### PR TITLE
Fixes a bug in useSimpleNavigation() that causes the page to reload d…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-storefront",
-  "version": "8.10.0",
+  "version": "8.10.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "clsx": "^1.0.4",
     "delegate": "^3.2.0",
     "formidable": "^1.2.1",
+    "glob": "^7.1.6",
     "isomorphic-unfetch": "^3.0.0",
     "next-offline": "^5.0.0",
     "qs": "^6.9.0",

--- a/src/server/listRoutes.js
+++ b/src/server/listRoutes.js
@@ -1,0 +1,49 @@
+import getRoutes from './getRoutes'
+import fs from 'fs'
+import path from 'path'
+import glob from 'glob'
+
+// Depending on the context (local dev, serverless lambda), the page manifest
+// file can be at different locations
+const MANIFEST_PATHS = [
+  path.join(process.cwd(), 'pages-manifest.json'),
+  path.join(process.cwd(), '.next', 'server', 'pages-manifest.json'),
+  path.join(process.cwd(), '.next', 'serverless', 'pages-manifest.json'),
+]
+
+export default function listRoutes() {
+  let manifest
+
+  if (process.env.NODE_ENV === 'production') {
+    const manifestPath = MANIFEST_PATHS.find(path => fs.existsSync(path))
+
+    /* istanbul ignore else */
+    if (manifestPath) {
+      manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'))
+    } else {
+      throw new Error(`Could not find pages-manifests.json in ${MANIFEST_PATHS.join(' or ')}`)
+    }
+  } else {
+    manifest = createDevelopmentPagesManifest()
+  }
+
+  return getRoutes(manifest)
+}
+
+/**
+ * Creates the equivalent of pages-manifest.json in development.  Since
+ * next.js incrementally compiles pages on demand in development, pages-manifest may
+ * not have all of the pages until they are visited and thus cannot be used by useSimpleNavigation
+ * reliably in development.
+ */
+function createDevelopmentPagesManifest() {
+  const pages = glob.sync('pages/**/*.js', { cwd: process.cwd() })
+  const manifest = {}
+
+  for (let page of pages) {
+    const route = page.replace(/^pages/, '').replace(/\.[^/]+$/, '')
+    manifest[route] = page
+  }
+
+  return manifest
+}

--- a/test/server/listRoutes.test.js
+++ b/test/server/listRoutes.test.js
@@ -1,0 +1,50 @@
+import { join } from 'path'
+
+describe('listRoutes', () => {
+  let originalDir, listRoutes
+
+  beforeEach(() => {
+    jest.isolateModules(() => {
+      originalDir = process.cwd()
+      process.chdir(join(__dirname, 'test-app'))
+      listRoutes = require('../../src/server/listRoutes').default
+    })
+  })
+
+  afterEach(() => {
+    process.chdir(originalDir)
+  })
+
+  describe('development', () => {
+    it('should return routes in development', () => {
+      expect(listRoutes()).toEqual({
+        '^\\/p\\/([^/]+?)(?:\\/)?$': {
+          as: '/p/[productId]',
+          component: 'pages/p/[productId].js',
+        },
+      })
+    })
+  })
+
+  describe('production', () => {
+    let nodeEnv
+
+    beforeEach(() => {
+      nodeEnv = process.env.NODE_ENV
+      process.env.NODE_ENV = 'production'
+    })
+
+    afterEach(() => {
+      process.env.NODE_ENV = nodeEnv
+    })
+
+    it('should return routes in production', () => {
+      expect(listRoutes()).toEqual({
+        '^\\/p\\/([^/]+?)(?:\\/)?$': {
+          as: '/p/[productId]',
+          component: 'pages/p/[productId].js',
+        },
+      })
+    })
+  })
+})

--- a/test/server/test-app/pages-manifest.json
+++ b/test/server/test-app/pages-manifest.json
@@ -1,0 +1,1 @@
+{ "/p/[productId]": "pages/p/[productId].js" }


### PR DESCRIPTION
…uring navigation in development.

This issue was caused by pages-manifest.json not containing all the routes during development.  This happens because Next.js only compiles pages when they are accessed for the first time. To fix this, we derive the routes by inspecting the file system.